### PR TITLE
fix TEMPLATE_DIRS error

### DIFF
--- a/leeyochou/settings.py
+++ b/leeyochou/settings.py
@@ -56,7 +56,7 @@ ROOT_URLCONF = 'leeyochou.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [os.path.join(BASE_DIR, 'templates')],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -68,10 +68,6 @@ TEMPLATES = [
         },
     },
 ]
-
-TEMPLATE_DIRS = (
-    os.path.join(BASE_DIR, 'templates').replace('\\', '/'),
-)
 
 WSGI_APPLICATION = 'leeyochou.wsgi.application'
 


### PR DESCRIPTION
TEMPLATE_DIRS was deprecated since version `1.8` !!!!!!!!!

:cry: :sob: :disappointed: :crying_cat_face:
:sake::sake::sake::sake::sake::sake: 
https://docs.djangoproject.com/en/1.8/ref/settings/#template-dirs
